### PR TITLE
Adds writeOnce and valueFn in the state configuration

### DIFF
--- a/src/pages/docs/guides/state.md
+++ b/src/pages/docs/guides/state.md
@@ -55,6 +55,10 @@ Calculator.STATE = {
         // Initial value
         value: 0,
 
+        // You can, instead of the `value` option above, use a function to 
+        // return the initial value for the state.
+        valueFn: val => 0,
+
         // It's also possible to define that a property can only receive a 
         // value once, and later behave as read-only.
         writeOnce: false

--- a/src/pages/docs/guides/state.md
+++ b/src/pages/docs/guides/state.md
@@ -53,7 +53,11 @@ Calculator.STATE = {
         validator: val => core.isNumber(val) || core.isString(val),
 
         // Initial value
-        value: 0
+        value: 0,
+
+        // It's also possible to define that a property can only receive a 
+        // value once, and later behave as read-only.
+        writeOnce: false
     }
 }
 ```


### PR DESCRIPTION
cc @brunobasto 

I think it's better we expose all State configuration options. We don't have that much. I also suggest removing the link to the source code [here](https://github.com/metal/metaljs.com/blame/master/src/pages/docs/guides/state.md#L67), the documentation is clear enough to don't need to look at the code.